### PR TITLE
Adds Support for Basic Dimmer Switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ typings/
 
 # next.js build output
 .next
+
+# vs code garbage
+.vscode

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@
 npm i homebridge-tuya -g
 ```
 
-## Example config.json
-
-The `type` option can be used to indicate the device is a dimmer. It can be set to "dimmer" or "generic", if omitted it will default to generic.
+## Basic config.json
 
 ```javascript
 {
@@ -32,9 +30,14 @@ The `type` option can be used to indicate the device is a dimmer. It can be set 
 }
 ```
 
-See [this page](https://github.com/codetheweb/tuyapi/blob/master/docs/SETUP.md) for finding the above parameters.
+Currently supported types (`type` field):
+- `generic`: a device that has a single, boolean property (such as outlets, light switches, etc). Can be used in combination with the `dps` option to set a custom property.
+- `dimmer`: light switches with dimmers
 
-When using parameters from captured requests/responses, seek for `devId` or `uuid` for `id` field, and `localKey` for `key` field.
+See [this guide](https://github.com/codetheweb/tuyapi/blob/master/docs/SETUP.md) for finding the `id` and `key`.
+
+
+## Advanced
 
 If you find that the built-in IP auto discovery doesn't work for your network setup, you can pass it in manually like so:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # homebridge-tuya
+
 🏠 Offical Homebridge plugin for [TuyAPI](https://github.com/codetheweb/tuyapi).
 
 ## Installation
@@ -9,20 +10,23 @@ npm i homebridge-tuya -g
 
 ## Example config.json
 
+The `type` option can be used to indicate the device is a dimmer. It can be set to "dimmer" or "generic", if omitted it will default to generic.
+
 ```javascript
 {
   "platform": "TuyaPlatform",
   "name": "TuyaPlatform",
   "devices": [
     {
-      "name": "Tuya Device 1",
+      "name": "Tuya Outlet Device 1",
       "id": "xxxxxxxxxxxxxxxxxxxx",
       "key": "xxxxxxxxxxxxxxxx"
     },
     {
-      "name": "Tuya Device 2",
+      "name": "Tuya Dimmer Switch Device 2",
       "id": "xxxxxxxxxxxxxxxxxxxx",
-      "key": "xxxxxxxxxxxxxxxx"
+      "key": "xxxxxxxxxxxxxxxx",
+      "type": "dimmer"
     }
   ]
 }
@@ -33,6 +37,7 @@ See [this page](https://github.com/codetheweb/tuyapi/blob/master/docs/SETUP.md) 
 When using parameters from captured requests/responses, seek for `devId` or `uuid` for `id` field, and `localKey` for `key` field.
 
 If you find that the built-in IP auto discovery doesn't work for your network setup, you can pass it in manually like so:
+
 ```javascript
 {
   "name": "Tuya Device 1",
@@ -43,6 +48,7 @@ If you find that the built-in IP auto discovery doesn't work for your network se
 ```
 
 For devices with more than one switch (for example, powerstrips), a config would look like this:
+
 ```javascript
 "devices": [
   {

--- a/index.js
+++ b/index.js
@@ -25,13 +25,13 @@ class TuyaPlatform {
 
     // When a new device is found, add it to Homebridge
     this.discovery.on('device-new', (device) => {
-      this.log.info('New Device Online: %s', device.id);
+      this.log.info('New Device Online: %s (%s)', device.name || 'unnamed', device.id);
       this.addAccessory(device);
     });
 
     // If a device is unreachable, remove it from Homebridge
     this.discovery.on('device-offline', (device) => {
-      this.log.info('Device Offline: %s', device.id);
+      this.log.info('Device Offline: %s (%s)', device.name || 'unnamed', device.id);
 
       const uuid = this.api.hap.uuid.generate(device.id + device.name);
       this.removeAccessory(this.homebridgeAccessories.get(uuid));
@@ -57,7 +57,7 @@ class TuyaPlatform {
   }
 
   addAccessory(device) {
-    this.log.info('Adding: %s', device.id);
+    this.log.info('Adding: %s (%s)', device.name || 'unnamed', device.id);
 
     // Get UUID
     const uuid = this.api.hap.uuid.generate(device.id + device.name);
@@ -77,6 +77,7 @@ class TuyaPlatform {
     }
 
     // Add to global map
+    this.log.info('Adding: %s (%s / %s)', device.name || 'unnamed', deviceType, device.id);
     this.homebridgeAccessories.set(uuid, deviceAccessory.homebridgeAccessory);
   }
 

--- a/index.js
+++ b/index.js
@@ -57,19 +57,23 @@ class TuyaPlatform {
     const device = this.config.devices.find((d) => d.id === accessory.context.deviceId) || {};
     const deviceType = device.type || 'generic';
 
-    // Construct new accessory
-    let deviceAccessory;
-    switch (deviceType) {
-      case 'dimmer':
-        deviceAccessory = new DimmerAccessory(this, accessory, device);
-        break;
-      case 'generic':
-      default:
-        deviceAccessory = new GenericAccessory(this, accessory, device);
-        break;
-    }
+    try {
+      // Construct new accessory
+      let deviceAccessory;
+      switch (deviceType) {
+        case 'dimmer':
+          deviceAccessory = new DimmerAccessory(this, accessory, device);
+          break;
+        case 'generic':
+        default:
+          deviceAccessory = new GenericAccessory(this, accessory, device);
+          break;
+      }
 
-    this.homebridgeAccessories.set(accessory.UUID, deviceAccessory.homebridgeAccessory);
+      this.homebridgeAccessories.set(accessory.UUID, deviceAccessory.homebridgeAccessory);
+    } catch (e) {
+      this.log.error(e);
+    }
   }
 
   addAccessory(device, knownId) {
@@ -80,20 +84,24 @@ class TuyaPlatform {
     const uuid = knownId || this.api.hap.uuid.generate(device.id + device.name);
     const homebridgeAccessory = this.homebridgeAccessories.get(uuid);
 
-    // Construct new accessory
-    let deviceAccessory;
-    switch (deviceType) {
-      case 'dimmer':
-        deviceAccessory = new DimmerAccessory(this, homebridgeAccessory, device);
-        break;
-      case 'generic':
-      default:
-        deviceAccessory = new GenericAccessory(this, homebridgeAccessory, device);
-        break;
-    }
+    try {
+      // Construct new accessory
+      let deviceAccessory;
+      switch (deviceType) {
+        case 'dimmer':
+          deviceAccessory = new DimmerAccessory(this, homebridgeAccessory, device);
+          break;
+        case 'generic':
+        default:
+          deviceAccessory = new GenericAccessory(this, homebridgeAccessory, device);
+          break;
+      }
 
-    // Add to global map
-    this.homebridgeAccessories.set(uuid, deviceAccessory.homebridgeAccessory);
+      // Add to global map
+      this.homebridgeAccessories.set(uuid, deviceAccessory.homebridgeAccessory);
+    } catch (e) {
+      this.log.error(e);
+    }
   }
 
   removeAccessory(homebridgeAccessory) {

--- a/index.js
+++ b/index.js
@@ -46,10 +46,30 @@ class TuyaPlatform {
 
   // Function invoked when homebridge tries to restore cached accessory
   configureAccessory(accessory) {
-    let device = this.config.devices.find((d) => d.deviceId === accessory.context.deviceId);
-    if (device) {
-      this.addAccessory(match, accessory.UUID);
+    this.log.info(
+      'Configuring cached accessory: [%s] %s %s',
+      accessory.displayName,
+      accessory.context.deviceId,
+      accessory.UUID
+    );
+    this.log.debug('%j', accessory);
+
+    const device = this.config.devices.find((d) => d.deviceId === accessory.context.deviceId) || {};
+    const deviceType = device.type || 'generic';
+
+    // Construct new accessory
+    let deviceAccessory;
+    switch (deviceType) {
+      case 'dimmer':
+        deviceAccessory = new DimmerAccessory(this, accessory, device);
+        break;
+      case 'generic':
+      default:
+        deviceAccessory = new GenericAccessory(this, accessory, device);
+        break;
     }
+
+    this.homebridgeAccessories.set(accessory.UUID, deviceAccessory.homebridgeAccessory);
   }
 
   addAccessory(device, knownId) {

--- a/index.js
+++ b/index.js
@@ -52,28 +52,8 @@ class TuyaPlatform {
       accessory.context.deviceId,
       accessory.UUID
     );
-    this.log.debug('%j', accessory);
-
-    const device = this.config.devices.find((d) => d.id === accessory.context.deviceId) || {};
-    const deviceType = device.type || 'generic';
-
-    try {
-      // Construct new accessory
-      let deviceAccessory;
-      switch (deviceType) {
-        case 'dimmer':
-          deviceAccessory = new DimmerAccessory(this, accessory, device);
-          break;
-        case 'generic':
-        default:
-          deviceAccessory = new GenericAccessory(this, accessory, device);
-          break;
-      }
-
-      this.homebridgeAccessories.set(accessory.UUID, deviceAccessory.homebridgeAccessory);
-    } catch (e) {
-      this.log.error(e);
-    }
+    this.log.info('%j', accessory);
+    this.homebridgeAccessories.set(accessory.UUID, accessory);
   }
 
   addAccessory(device, knownId) {
@@ -84,28 +64,20 @@ class TuyaPlatform {
     const uuid = knownId || this.api.hap.uuid.generate(device.id + device.name);
     const homebridgeAccessory = this.homebridgeAccessories.get(uuid);
 
-    try {
-      // Construct new accessory
-      let deviceAccessory;
-      switch (deviceType) {
-        case 'dimmer':
-          deviceAccessory = new DimmerAccessory(this, homebridgeAccessory, device);
-          break;
-        case 'generic':
-        default:
-          deviceAccessory = new GenericAccessory(this, homebridgeAccessory, device);
-          break;
-      }
-
-      // Add to global map
-      if (this.homebridgeAccessories.has(uuid)) {
-        this.homebridgeAccessories.delete(uuid);
-      }
-
-      this.homebridgeAccessories.set(uuid, deviceAccessory.homebridgeAccessory);
-    } catch (e) {
-      this.log.error(e);
+    // Construct new accessory
+    let deviceAccessory;
+    switch (deviceType) {
+      case 'dimmer':
+        deviceAccessory = new DimmerAccessory(this, homebridgeAccessory, device);
+        break;
+      case 'generic':
+      default:
+        deviceAccessory = new GenericAccessory(this, homebridgeAccessory, device);
+        break;
     }
+
+    // Add to global map
+    this.homebridgeAccessories.set(uuid, deviceAccessory.homebridgeAccessory);
   }
 
   removeAccessory(homebridgeAccessory) {

--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ class TuyaPlatform {
   configureAccessory(accessory) {
     let hit = this.cache[accessory.context.deviceId];
     if (!hit) {
+      this.cache[accessory.context.deviceId] = true;
       this.log.info(
         'Configuring cached accessory: [%s] %s %s',
         accessory.displayName,
@@ -63,6 +64,7 @@ class TuyaPlatform {
   addAccessory(device) {
     let hit = this.cache[device.id];
     if (!hit) {
+      this.cache[device.id] = true;
       const deviceType = device.type || 'generic';
       this.log.info('Adding: %s (%s / %s)', device.name || 'unnamed', deviceType, device.id);
 

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ class TuyaPlatform {
     );
     this.log.debug('%j', accessory);
 
-    const device = this.config.devices.find((d) => d.deviceId === accessory.context.deviceId) || {};
+    const device = this.config.devices.find((d) => d.id === accessory.context.deviceId) || {};
     const deviceType = device.type || 'generic';
 
     // Construct new accessory

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const TuyaDiscover = require('./lib/discovery');
+const DimmerAccessory = require('./lib/dimmer');
 const GenericAccessory = require('./lib/generic');
 
 class TuyaPlatform {
@@ -23,13 +24,13 @@ class TuyaPlatform {
     });
 
     // When a new device is found, add it to Homebridge
-    this.discovery.on('device-new', device => {
+    this.discovery.on('device-new', (device) => {
       this.log.info('New Device Online: %s', device.id);
       this.addAccessory(device);
     });
 
     // If a device is unreachable, remove it from Homebridge
-    this.discovery.on('device-offline', device => {
+    this.discovery.on('device-offline', (device) => {
       this.log.info('Device Offline: %s', device.id);
 
       const uuid = this.api.hap.uuid.generate(device.id + device.name);
@@ -45,7 +46,12 @@ class TuyaPlatform {
 
   // Function invoked when homebridge tries to restore cached accessory
   configureAccessory(accessory) {
-    this.log.info('Configuring cached accessory: [%s] %s %s', accessory.displayName, accessory.context.deviceId, accessory.UUID);
+    this.log.info(
+      'Configuring cached accessory: [%s] %s %s',
+      accessory.displayName,
+      accessory.context.deviceId,
+      accessory.UUID
+    );
     this.log.debug('%j', accessory);
     this.homebridgeAccessories.set(accessory.UUID, accessory);
   }
@@ -57,8 +63,18 @@ class TuyaPlatform {
     const uuid = this.api.hap.uuid.generate(device.id + device.name);
     const homebridgeAccessory = this.homebridgeAccessories.get(uuid);
 
-    // Construct new generic accessory
-    const deviceAccessory = new GenericAccessory(this, homebridgeAccessory, device);
+    // Construct new accessory
+    let deviceAccessory;
+    const deviceType = device.type || 'generic';
+    switch (deviceType) {
+      case 'dimmer':
+        deviceAccessory = new DimmerAccessory(this, homebridgeAccessory, device);
+        break;
+      case 'generic':
+      default:
+        deviceAccessory = new GenericAccessory(this, homebridgeAccessory, device);
+        break;
+    }
 
     // Add to global map
     this.homebridgeAccessories.set(uuid, deviceAccessory.homebridgeAccessory);
@@ -72,10 +88,12 @@ class TuyaPlatform {
     this.log.info('Removing: %s', homebridgeAccessory.displayName);
 
     this.homebridgeAccessories.delete(homebridgeAccessory.deviceId);
-    this.api.unregisterPlatformAccessories('homebridge-tuya', 'TuyaPlatform', [homebridgeAccessory]);
+    this.api.unregisterPlatformAccessories('homebridge-tuya', 'TuyaPlatform', [
+      homebridgeAccessory,
+    ]);
   }
 }
 
-module.exports = function (homebridge) {
+module.exports = function(homebridge) {
   homebridge.registerPlatform('homebridge-tuya', 'TuyaPlatform', TuyaPlatform, true);
 };

--- a/index.js
+++ b/index.js
@@ -50,15 +50,6 @@ class TuyaPlatform {
     if (device) {
       this.addAccessory(match, accessory.UUID);
     }
-
-    this.log.info(
-      'Configuring cached accessory: [%s] %s %s',
-      accessory.displayName,
-      accessory.context.deviceId,
-      accessory.UUID
-    );
-    this.log.debug('%j', accessory);
-    this.homebridgeAccessories.set(accessory.UUID, accessory);
   }
 
   addAccessory(device, knownId) {

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ class TuyaPlatform {
   }
 
   addAccessory(device) {
-    let hit = this.cache[accessory.context.deviceId];
+    let hit = this.cache[device.id];
     if (!hit) {
       const deviceType = device.type || 'generic';
       this.log.info('Adding: %s (%s / %s)', device.name || 'unnamed', deviceType, device.id);

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ class TuyaPlatform {
     this.log = log;
     this.config = config || {};
     this.api = api;
+    this.cache = {};
 
     // Keep track of all registered accessories
     this.homebridgeAccessories = new Map();
@@ -46,39 +47,44 @@ class TuyaPlatform {
 
   // Function invoked when homebridge tries to restore cached accessory
   configureAccessory(accessory) {
-    this.log.info(
-      'Configuring cached accessory: [%s] %s %s',
-      accessory.displayName,
-      accessory.context.deviceId,
-      accessory.UUID
-    );
-    this.log.debug('%j', accessory);
-    this.homebridgeAccessories.set(accessory.UUID, accessory);
+    let hit = this.cache[accessory.context.deviceId];
+    if (!hit) {
+      this.log.info(
+        'Configuring cached accessory: [%s] %s %s',
+        accessory.displayName,
+        accessory.context.deviceId,
+        accessory.UUID
+      );
+      this.log.debug('%j', accessory);
+      this.homebridgeAccessories.set(accessory.UUID, accessory);
+    }
   }
 
   addAccessory(device) {
-    this.log.info('Adding: %s (%s)', device.name || 'unnamed', device.id);
+    let hit = this.cache[accessory.context.deviceId];
+    if (!hit) {
+      const deviceType = device.type || 'generic';
+      this.log.info('Adding: %s (%s / %s)', device.name || 'unnamed', deviceType, device.id);
 
-    // Get UUID
-    const uuid = this.api.hap.uuid.generate(device.id + device.name);
-    const homebridgeAccessory = this.homebridgeAccessories.get(uuid);
+      // Get UUID
+      const uuid = this.api.hap.uuid.generate(device.id + device.name);
+      const homebridgeAccessory = this.homebridgeAccessories.get(uuid);
 
-    // Construct new accessory
-    let deviceAccessory;
-    const deviceType = device.type || 'generic';
-    switch (deviceType) {
-      case 'dimmer':
-        deviceAccessory = new DimmerAccessory(this, homebridgeAccessory, device);
-        break;
-      case 'generic':
-      default:
-        deviceAccessory = new GenericAccessory(this, homebridgeAccessory, device);
-        break;
+      // Construct new accessory
+      let deviceAccessory;
+      switch (deviceType) {
+        case 'dimmer':
+          deviceAccessory = new DimmerAccessory(this, homebridgeAccessory, device);
+          break;
+        case 'generic':
+        default:
+          deviceAccessory = new GenericAccessory(this, homebridgeAccessory, device);
+          break;
+      }
+
+      // Add to global map
+      this.homebridgeAccessories.set(uuid, deviceAccessory.homebridgeAccessory);
     }
-
-    // Add to global map
-    this.log.info('Adding: %s (%s / %s)', device.name || 'unnamed', deviceType, device.id);
-    this.homebridgeAccessories.set(uuid, deviceAccessory.homebridgeAccessory);
   }
 
   removeAccessory(homebridgeAccessory) {

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ class TuyaPlatform {
       accessory.context.deviceId,
       accessory.UUID
     );
-    this.log.info('%j', accessory);
+    this.log.debug('%j', accessory);
     this.homebridgeAccessories.set(accessory.UUID, accessory);
   }
 

--- a/index.js
+++ b/index.js
@@ -98,6 +98,10 @@ class TuyaPlatform {
       }
 
       // Add to global map
+      if (this.homebridgeAccessories.has(uuid)) {
+        this.homebridgeAccessories.delete(uuid);
+      }
+
       this.homebridgeAccessories.set(uuid, deviceAccessory.homebridgeAccessory);
     } catch (e) {
       this.log.error(e);

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -89,13 +89,13 @@ class DimmerAccessory {
     this.dimmerService
       .getCharacteristic(Characteristic.Brightness)
       .on('get', (callback) => {
-        this.log.info('[%s] On get brightness', this.homebridgeAccessory.displayName);
+        this.log.debug('[%s] On get brightness', this.homebridgeAccessory.displayName);
 
         this.device
           .get({ dps: this.dpsMap.brightness })
           .then((status) => {
             const val = Math.ceil((status - this.minVal) / this.maxVal) * 100;
-            this.log.info(
+            this.log.debug(
               '[%s] \tGet brightness %s from %s',
               this.homebridgeAccessory.displayName,
               val,
@@ -109,10 +109,10 @@ class DimmerAccessory {
           });
       })
       .on('set', (value, callback) => {
-        this.log.info('[%s] On set brightness', this.homebridgeAccessory.displayName);
+        this.log.debug('[%s] On set brightness', this.homebridgeAccessory.displayName);
 
         const val = this.minVal + Math.ceil((value * this.maxVal) / 100);
-        this.log.info(
+        this.log.debug(
           '[%s] \tSet brightness %s from %s',
           this.homebridgeAccessory.displayName,
           val,

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -20,6 +20,8 @@ class DimmerAccessory {
       onOff: deviceConfig.dpsOn || 1,
       brightness: deviceConfig.dpsBright || 2,
     };
+    this.deviceConfig.minVal = this.deviceConfig.minVal || 11;
+    this.deviceConfig.maxVal = this.deviceConfig.maxVal || 244;
     this.dimmerTimeout = null;
     this.device = new TuyaDevice(deviceConfig);
 
@@ -93,7 +95,8 @@ class DimmerAccessory {
         this.device
           .get({ dps: this.deviceConfig.dpsMap.brightness })
           .then((status) => {
-            callback(null, status);
+            const val = Math.ceil((status - this.deviceConfig.minVal) / this.deviceConfig.maxVal);
+            callback(null, val);
           })
           .catch((error) => {
             this.log.error(error);
@@ -105,14 +108,12 @@ class DimmerAccessory {
 
         this.dimmerTimeout = setTimeout(
           function(self, value, callback) {
-            self.log.debug(
-              '[%s] On set brightness %s',
-              self.homebridgeAccessory.displayName,
-              value
-            );
+            const val =
+              this.deviceConfig.minVal + Math.ceil((value * this.deviceConfig.maxVal) / 100);
+            self.log.debug('[%s] On set brightness %s', self.homebridgeAccessory.displayName, val);
 
             self.device
-              .set({ set: value, dps: self.deviceConfig.dpsMap.brightness })
+              .set({ set: val, dps: self.deviceConfig.dpsMap.brightness })
               .catch((error) => {
                 self.log.error(error);
                 callback(error);

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -67,11 +67,12 @@ class DimmerAccessory {
             callback(null, status);
           })
           .catch((error) => {
+            this.log.error(error);
             callback(error);
           });
       })
       .on('set', (value, callback) => {
-        this.log.info('[%s] On set $s', this.homebridgeAccessory.displayName, value);
+        this.log.info('[%s] On set %s', this.homebridgeAccessory.displayName, value);
 
         this.device
           .set({ set: value, dps: this.deviceConfig.dpsMap.onOff })
@@ -79,6 +80,7 @@ class DimmerAccessory {
             callback();
           })
           .catch((error) => {
+            this.log.error(error);
             callback(error);
           });
       });
@@ -91,21 +93,25 @@ class DimmerAccessory {
         this.device
           .get({ dps: this.deviceConfig.dpsMap.brightness })
           .then((status) => {
-            callback(null, status);
+            const val = Math.ceil(100 / (255 / status));
+            callback(null, val);
           })
           .catch((error) => {
+            this.log.error(error);
             callback(error);
           });
       })
       .on('set', (value, callback) => {
         this.log.info('[%s] On set brightness to %s', this.homebridgeAccessory.displayName, value);
 
+        const val = Math.floor(255 * (pct / 100));
         this.device
-          .set({ set: value, dps: this.deviceConfig.dpsMap.brightness })
+          .set({ set: val, dps: this.deviceConfig.dpsMap.brightness })
           .then(() => {
             callback();
           })
           .catch((error) => {
+            this.log.error(error);
             callback(error);
           });
       });

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -6,23 +6,6 @@ let Service;
 let Characteristic;
 let UUIDGen;
 
-// Base on a 5-stage dimmer switch
-const vals = [0, 20, 40, 60, 80, 100];
-
-function closest(num) {
-  const arr = vals;
-  var curr = arr[0];
-  var diff = Math.abs(num - curr);
-  for (var val = 0; val < arr.length; val++) {
-    var newdiff = Math.abs(num - arr[val]);
-    if (newdiff < diff) {
-      diff = newdiff;
-      curr = arr[val];
-    }
-  }
-  return curr;
-}
-
 class DimmerAccessory {
   constructor(platform, homebridgeAccessory, deviceConfig) {
     this.platform = platform;
@@ -110,7 +93,7 @@ class DimmerAccessory {
         this.device
           .get({ dps: this.deviceConfig.dpsMap.brightness })
           .then((status) => {
-            const val = closest(Math.ceil(100 / (255 / status)));
+            const val = Math.ceil(100 / (255 / status));
             callback(null, val);
           })
           .catch((error) => {
@@ -123,8 +106,7 @@ class DimmerAccessory {
 
         this.dimmerTimeout = setTimeout(
           function(self, value, callback) {
-            const pct = closest(value);
-            const val = Math.floor(255 * (pct / 100));
+            const val = Math.ceil(255 * (value / 100));
             self.log.debug('[%s] On set brightness %s', self.homebridgeAccessory.displayName, val);
 
             self.device

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -93,34 +93,34 @@ class DimmerAccessory {
 
         this.device
           .get({ dps: this.dpsMap.brightness })
-          .then((status) => {
-            const val = Math.ceil((status - this.minVal) / this.maxVal) * 100;
+          .then((value) => {
+            const percent = Math.floor(((value - this.minVal) / this.maxVal) * 100);
             this.log.debug(
               '[%s] \tGet brightness %s from %s',
               this.homebridgeAccessory.displayName,
-              val,
-              status
+              percent,
+              value
             );
-            callback(null, val);
+            callback(null, percent);
           })
           .catch((error) => {
             this.log.error(error);
             callback(error);
           });
       })
-      .on('set', (value, callback) => {
+      .on('set', (percent, callback) => {
         this.log.debug('[%s] On set brightness', this.homebridgeAccessory.displayName);
 
-        const val = this.minVal + Math.ceil((value * this.maxVal) / 100);
+        const value = Math.ceil((percent * this.maxVal) / 100) + this.minVal;
         this.log.debug(
           '[%s] \tSet brightness %s from %s',
           this.homebridgeAccessory.displayName,
-          val,
-          value
+          value,
+          percent
         );
 
         this.device
-          .set({ set: val, dps: this.dpsMap.brightness })
+          .set({ set: value, dps: this.dpsMap.brightness })
           .then(() => {
             callback();
           })

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -24,6 +24,9 @@ class DimmerAccessory {
     this.device = new TuyaDevice(deviceConfig);
 
     if (this.homebridgeAccessory) {
+      if (!this.homebridgeAccessory.context.deviceId)
+        this.homebridgeAccessory.context.deviceId = this.deviceConfig.id;
+
       this.log.info(
         'Existing Accessory found [%s] [%s] [%s]',
         homebridgeAccessory.displayName,

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -111,21 +111,21 @@ class DimmerAccessory {
       .on('set', (value, callback) => {
         this.log.info('[%s] On set brightness', this.homebridgeAccessory.displayName);
 
-        const val = self.minVal + Math.ceil((value * self.maxVal) / 100);
-        self.log.info(
+        const val = this.minVal + Math.ceil((value * this.maxVal) / 100);
+        this.log.info(
           '[%s] \tSet brightness %s from %s',
-          self.homebridgeAccessory.displayName,
+          this.homebridgeAccessory.displayName,
           val,
           value
         );
 
-        self.device
-          .set({ set: val, dps: self.dpsMap.brightness })
+        this.device
+          .set({ set: val, dps: this.dpsMap.brightness })
           .then(() => {
             callback();
           })
           .catch((error) => {
-            self.log.error(error);
+            this.log.error(error);
             callback(error);
           });
       });

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -93,8 +93,7 @@ class DimmerAccessory {
         this.device
           .get({ dps: this.deviceConfig.dpsMap.brightness })
           .then((status) => {
-            const val = Math.ceil(100 / (255 / status));
-            callback(null, val);
+            callback(null, status);
           })
           .catch((error) => {
             this.log.error(error);
@@ -106,11 +105,14 @@ class DimmerAccessory {
 
         this.dimmerTimeout = setTimeout(
           function(self, value, callback) {
-            const val = Math.ceil(255 * (value / 100));
-            self.log.debug('[%s] On set brightness %s', self.homebridgeAccessory.displayName, val);
+            self.log.debug(
+              '[%s] On set brightness %s',
+              self.homebridgeAccessory.displayName,
+              value
+            );
 
             self.device
-              .set({ set: val, dps: self.deviceConfig.dpsMap.brightness })
+              .set({ set: value, dps: self.deviceConfig.dpsMap.brightness })
               .catch((error) => {
                 self.log.error(error);
                 callback(error);

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -119,9 +119,8 @@ class DimmerAccessory {
           });
       })
       .on('set', (value, callback) => {
-        if (this.dimmerTimeout) {
-          clearTimeout(this.dimmerTimeout);
-        }
+        clearTimeout(this.dimmerTimeout);
+
         this.dimmerTimeout = setTimeout(
           function(self, value, callback) {
             const pct = closest(value);
@@ -130,9 +129,9 @@ class DimmerAccessory {
 
             self.device
               .set({ set: val, dps: self.deviceConfig.dpsMap.brightness })
-              .then(() => {
+              /* .then(() => {
                 callback();
-              })
+              }) */
               .catch((error) => {
                 self.log.error(error);
                 callback(error);
@@ -144,6 +143,7 @@ class DimmerAccessory {
           value,
           callback
         );
+        callback();
       });
 
     this.homebridgeAccessory.on('identify', (paired, callback) => {

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -111,11 +111,11 @@ class DimmerAccessory {
       })
       .on('set', (value, callback) => {
         clearTimeout(this.dimmerTimeout);
-        self.log.info('[%s] On set brightness', self.homebridgeAccessory.displayName);
+        this.log.info('[%s] On set brightness', self.homebridgeAccessory.displayName);
 
         this.dimmerTimeout = setTimeout(
           function(self, value, callback) {
-            const val = this.minVal + Math.ceil((value * this.maxVal) / 100);
+            const val = self.minVal + Math.ceil((value * self.maxVal) / 100);
             self.log.info(
               '[%s] \tSet brightness %s from %s',
               self.homebridgeAccessory.displayName,

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -24,7 +24,7 @@ class DimmerAccessory {
     this.device = new TuyaDevice(deviceConfig);
 
     if (this.homebridgeAccessory) {
-      this.log.debug(
+      this.log.info(
         'Existing Accessory found [%s] [%s] [%s]',
         homebridgeAccessory.displayName,
         homebridgeAccessory.context.deviceId,
@@ -32,7 +32,7 @@ class DimmerAccessory {
       );
       this.homebridgeAccessory.displayName = this.deviceConfig.name;
     } else {
-      this.log.debug('Creating new Accessory %s', this.deviceConfig.id);
+      this.log.info('Creating new Accessory %s', this.deviceConfig.id);
       this.homebridgeAccessory = new PlatformAccessory(
         this.deviceConfig.name,
         UUIDGen.generate(this.deviceConfig.id + this.deviceConfig.name),
@@ -55,7 +55,7 @@ class DimmerAccessory {
     this.dimmerService
       .getCharacteristic(Characteristic.On)
       .on('get', (callback) => {
-        this.log.debug('[%s] On get', this.homebridgeAccessory.displayName);
+        this.log.info('[%s] On get', this.homebridgeAccessory.displayName);
 
         this.device
           .get({ dps: this.deviceConfig.dpsMap.onOff })
@@ -67,7 +67,7 @@ class DimmerAccessory {
           });
       })
       .on('set', (value, callback) => {
-        this.log.debug('[%s] On set', this.homebridgeAccessory.displayName);
+        this.log.info('[%s] On set $s', this.homebridgeAccessory.displayName, value);
 
         this.device
           .set({ set: value, dps: this.deviceConfig.dpsMap.onOff })
@@ -82,7 +82,7 @@ class DimmerAccessory {
     this.dimmerService
       .getCharacteristic(Characteristic.Brightness)
       .on('get', (callback) => {
-        this.log.debug('[%s] On get', this.homebridgeAccessory.displayName);
+        this.log.info('[%s] On get brightness', this.homebridgeAccessory.displayName);
 
         this.device
           .get({ dps: this.deviceConfig.dpsMap.brightness })
@@ -94,7 +94,7 @@ class DimmerAccessory {
           });
       })
       .on('set', (value, callback) => {
-        this.log.debug('[%s] On set', this.homebridgeAccessory.displayName);
+        this.log.info('[%s] On set brightness to %s', this.homebridgeAccessory.displayName, value);
 
         this.device
           .set({ set: value, dps: this.deviceConfig.dpsMap.brightness })

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -122,22 +122,28 @@ class DimmerAccessory {
         if (this.dimmerTimeout) {
           clearTimeout(this.dimmerTimeout);
         }
-        this.dimmerTimeout = setTimeout(function() {
-          const pct = closest(value);
-          const val = Math.floor(255 * (pct / 100));
-          this.log.debug('[%s] On set brightness %s', this.homebridgeAccessory.displayName, val);
+        this.dimmerTimeout = setTimeout(
+          function(self, value, callback) {
+            const pct = closest(value);
+            const val = Math.floor(255 * (pct / 100));
+            self.log.debug('[%s] On set brightness %s', self.homebridgeAccessory.displayName, val);
 
-          this.device
-            .set({ set: val, dps: this.deviceConfig.dpsMap.brightness })
-            .then(() => {
-              callback(null, pct);
-            })
-            .catch((error) => {
-              this.log.error(error);
-              callback(error);
-            });
-          this.dimmerTimeout = null;
-        }, 100);
+            self.device
+              .set({ set: val, dps: self.deviceConfig.dpsMap.brightness })
+              .then(() => {
+                callback(null, pct);
+              })
+              .catch((error) => {
+                self.log.error(error);
+                callback(error);
+              });
+            self.dimmerTimeout = null;
+          },
+          100,
+          this,
+          value,
+          callback
+        );
       });
 
     this.homebridgeAccessory.on('identify', (paired, callback) => {

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -94,6 +94,12 @@ class DimmerAccessory {
           .get({ dps: this.deviceConfig.dpsMap.brightness })
           .then((status) => {
             const val = Math.ceil(100 / (255 / status));
+            this.log.info(
+              '[%s] On get brightness is %s - %s',
+              this.homebridgeAccessory.displayName,
+              status,
+              val
+            );
             callback(null, val);
           })
           .catch((error) => {
@@ -102,9 +108,14 @@ class DimmerAccessory {
           });
       })
       .on('set', (value, callback) => {
-        this.log.info('[%s] On set brightness to %s', this.homebridgeAccessory.displayName, value);
-
         const val = Math.floor(255 * (pct / 100));
+        this.log.info(
+          '[%s] On set brightness to %s - %s',
+          this.homebridgeAccessory.displayName,
+          value,
+          val
+        );
+
         this.device
           .set({ set: val, dps: this.deviceConfig.dpsMap.brightness })
           .then(() => {

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -76,7 +76,7 @@ class DimmerAccessory {
     this.dimmerService
       .getCharacteristic(Characteristic.On)
       .on('get', (callback) => {
-        this.log.info('[%s] On get', this.homebridgeAccessory.displayName);
+        this.log.debug('[%s] On get', this.homebridgeAccessory.displayName);
 
         this.device
           .get({ dps: this.deviceConfig.dpsMap.onOff })
@@ -90,7 +90,7 @@ class DimmerAccessory {
       })
       .on('set', (value, callback) => {
         setTimeout();
-        this.log.info('[%s] On set %s', this.homebridgeAccessory.displayName, value);
+        this.log.debug('[%s] On set %s', this.homebridgeAccessory.displayName, value);
 
         this.device
           .set({ set: value, dps: this.deviceConfig.dpsMap.onOff })
@@ -106,7 +106,7 @@ class DimmerAccessory {
     this.dimmerService
       .getCharacteristic(Characteristic.Brightness)
       .on('get', (callback) => {
-        this.log.info('[%s] On get brightness', this.homebridgeAccessory.displayName);
+        this.log.debug('[%s] On get brightness', this.homebridgeAccessory.displayName);
 
         this.device
           .get({ dps: this.deviceConfig.dpsMap.brightness })
@@ -126,6 +126,8 @@ class DimmerAccessory {
         this.dimmerTimeout = setTimeout(() => {
           const pct = closest(value);
           const val = Math.floor(255 * (pct / 100));
+          this.log.debug('[%s] On set brightness %s', this.homebridgeAccessory.displayName, val);
+
           this.device
             .set({ set: val, dps: this.deviceConfig.dpsMap.brightness })
             .then(() => {

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -16,12 +16,12 @@ class DimmerAccessory {
     this.log = platform.log;
     this.homebridgeAccessory = homebridgeAccessory;
     this.deviceConfig = deviceConfig;
-    this.deviceConfig.dpsMap = {
+    this.dpsMap = {
       onOff: deviceConfig.dpsOn || 1,
       brightness: deviceConfig.dpsBright || 2,
     };
-    this.deviceConfig.minVal = this.deviceConfig.minVal || 11;
-    this.deviceConfig.maxVal = this.deviceConfig.maxVal || 244;
+    this.minVal = this.deviceConfig.minVal || 11;
+    this.maxVal = this.deviceConfig.maxVal || 244;
     this.dimmerTimeout = null;
     this.device = new TuyaDevice(deviceConfig);
 
@@ -64,7 +64,7 @@ class DimmerAccessory {
         this.log.debug('[%s] On get', this.homebridgeAccessory.displayName);
 
         this.device
-          .get({ dps: this.deviceConfig.dpsMap.onOff })
+          .get({ dps: this.dpsMap.onOff })
           .then((status) => {
             callback(null, status);
           })
@@ -77,7 +77,7 @@ class DimmerAccessory {
         this.log.debug('[%s] On set %s', this.homebridgeAccessory.displayName, value);
 
         this.device
-          .set({ set: value, dps: this.deviceConfig.dpsMap.onOff })
+          .set({ set: value, dps: this.dpsMap.onOff })
           .then(() => {
             callback();
           })
@@ -90,12 +90,14 @@ class DimmerAccessory {
     this.dimmerService
       .getCharacteristic(Characteristic.Brightness)
       .on('get', (callback) => {
+        this.log.info('[%s] On get brightness', this.homebridgeAccessory.displayName);
+
         this.device
-          .get({ dps: this.deviceConfig.dpsMap.brightness })
+          .get({ dps: this.dpsMap.brightness })
           .then((status) => {
-            const val = Math.ceil((status - this.deviceConfig.minVal) / this.deviceConfig.maxVal);
+            const val = Math.ceil((status - this.minVal) / this.maxVal);
             this.log.info(
-              '[%s] On get brightness %s from %s',
+              '[%s] \tGet brightness %s from %s',
               this.homebridgeAccessory.displayName,
               val,
               status
@@ -109,24 +111,22 @@ class DimmerAccessory {
       })
       .on('set', (value, callback) => {
         clearTimeout(this.dimmerTimeout);
+        self.log.info('[%s] On set brightness', self.homebridgeAccessory.displayName);
 
         this.dimmerTimeout = setTimeout(
           function(self, value, callback) {
-            const val =
-              this.deviceConfig.minVal + Math.ceil((value * this.deviceConfig.maxVal) / 100);
+            const val = this.minVal + Math.ceil((value * this.maxVal) / 100);
             self.log.info(
-              '[%s] On set brightness %s from ',
+              '[%s] \tSet brightness %s from %s',
               self.homebridgeAccessory.displayName,
               val,
               value
             );
 
-            self.device
-              .set({ set: val, dps: self.deviceConfig.dpsMap.brightness })
-              .catch((error) => {
-                self.log.error(error);
-                callback(error);
-              });
+            self.device.set({ set: val, dps: self.dpsMap.brightness }).catch((error) => {
+              self.log.error(error);
+              callback(error);
+            });
             self.dimmerTimeout = null;
           },
           this.deviceConfig.delay || 1000,

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -38,6 +38,7 @@ class DimmerAccessory {
         UUIDGen.generate(this.deviceConfig.id + this.deviceConfig.name),
         Accessory.Categories.LIGHTBULB
       );
+      this.homebridgeAccessory.context.deviceId = this.deviceConfig.id;
       platform.registerPlatformAccessory(this.homebridgeAccessory);
     }
 

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -17,8 +17,8 @@ class DimmerAccessory {
     this.homebridgeAccessory = homebridgeAccessory;
     this.deviceConfig = deviceConfig;
     this.deviceConfig.dpsMap = {
-      onOff = deviceConfig.dpsOn || 1,
-      brightness = deviceConfig.dpsBright || 2
+      onOff: deviceConfig.dpsOn || 1,
+      brightness: deviceConfig.dpsBright || 2,
     };
 
     this.device = new TuyaDevice(deviceConfig);

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -123,7 +123,7 @@ class DimmerAccessory {
         if (this.dimmerTimeout) {
           clearTimeout(this.dimmerTimeout);
         }
-        this.dimmerTimeout = setTimeout(() => {
+        this.dimmerTimeout = setTimeout(function() {
           const pct = closest(value);
           const val = Math.floor(255 * (pct / 100));
           this.log.debug('[%s] On set brightness %s', this.homebridgeAccessory.displayName, val);

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -95,7 +95,7 @@ class DimmerAccessory {
         this.device
           .get({ dps: this.dpsMap.brightness })
           .then((status) => {
-            const val = Math.ceil((status - this.minVal) / this.maxVal);
+            const val = Math.ceil((status - this.minVal) / this.maxVal) * 100;
             this.log.info(
               '[%s] \tGet brightness %s from %s',
               this.homebridgeAccessory.displayName,
@@ -111,7 +111,7 @@ class DimmerAccessory {
       })
       .on('set', (value, callback) => {
         clearTimeout(this.dimmerTimeout);
-        this.log.info('[%s] On set brightness', self.homebridgeAccessory.displayName);
+        this.log.info('[%s] On set brightness', this.homebridgeAccessory.displayName);
 
         this.dimmerTimeout = setTimeout(
           function(self, value, callback) {

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -123,28 +123,30 @@ class DimmerAccessory {
         if (this.dimmerTimeout) {
           clearTimeout(this.dimmerTimeout);
         }
-        this.dimmerTimeout = setTimeout(function() {
-          const pct = closest(value);
-          const val = Math.floor(255 * (pct / 100));
-          this.log.debug('[%s] On set brightness %s', this.homebridgeAccessory.displayName, val);
-
-          this.device
-            .set({ set: val, dps: this.deviceConfig.dpsMap.brightness })
-            .then(() => {
-              callback(null, pct);
-            })
-            .catch((error) => {
-              this.log.error(error);
-              callback(error);
-            });
-          this.dimmerTimeout = null;
-        }, 100);
+        this.dimmerTimeout = setTimeout(this.delaySetBrightness, 100, value, callback);
       });
 
     this.homebridgeAccessory.on('identify', (paired, callback) => {
       this.log.debug('[%s] identify', this.homebridgeAccessory.displayName);
       callback();
     });
+
+    function delaySetBrightness(value, callback) {
+      const pct = closest(value);
+      const val = Math.floor(255 * (pct / 100));
+      this.log.debug('[%s] On set brightness %s', this.homebridgeAccessory.displayName, val);
+
+      this.device
+        .set({ set: val, dps: this.deviceConfig.dpsMap.brightness })
+        .then(() => {
+          callback(null, pct);
+        })
+        .catch((error) => {
+          this.log.error(error);
+          callback(error);
+        });
+      this.dimmerTimeout = null;
+    }
   }
 }
 

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -90,12 +90,16 @@ class DimmerAccessory {
     this.dimmerService
       .getCharacteristic(Characteristic.Brightness)
       .on('get', (callback) => {
-        this.log.debug('[%s] On get brightness', this.homebridgeAccessory.displayName);
-
         this.device
           .get({ dps: this.deviceConfig.dpsMap.brightness })
           .then((status) => {
             const val = Math.ceil((status - this.deviceConfig.minVal) / this.deviceConfig.maxVal);
+            this.log.info(
+              '[%s] On get brightness %s from %s',
+              this.homebridgeAccessory.displayName,
+              val,
+              status
+            );
             callback(null, val);
           })
           .catch((error) => {
@@ -110,7 +114,12 @@ class DimmerAccessory {
           function(self, value, callback) {
             const val =
               this.deviceConfig.minVal + Math.ceil((value * this.deviceConfig.maxVal) / 100);
-            self.log.debug('[%s] On set brightness %s', self.homebridgeAccessory.displayName, val);
+            self.log.info(
+              '[%s] On set brightness %s from ',
+              self.homebridgeAccessory.displayName,
+              val,
+              value
+            );
 
             self.device
               .set({ set: val, dps: self.deviceConfig.dpsMap.brightness })

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -126,24 +126,25 @@ class DimmerAccessory {
           function(self, value, callback) {
             const pct = closest(value);
             const val = Math.floor(255 * (pct / 100));
-            self.log.debug('[%s] On set brightness %s', self.homebridgeAccessory.displayName, val);
+            self.log.info('[%s] On set brightness %s', self.homebridgeAccessory.displayName, val);
 
             self.device
               .set({ set: val, dps: self.deviceConfig.dpsMap.brightness })
-              .then(() => {
-                callback(null, pct);
-              })
+              /* .then(() => {
+                callback();
+              }) */
               .catch((error) => {
                 self.log.error(error);
                 callback(error);
               });
             self.dimmerTimeout = null;
           },
-          100,
+          250,
           this,
           value,
           callback
         );
+        callback();
       });
 
     this.homebridgeAccessory.on('identify', (paired, callback) => {

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -6,6 +6,22 @@ let Service;
 let Characteristic;
 let UUIDGen;
 
+// Base on a 5-stage dimmer switch
+const vals = [0, 20, 40, 60, 80, 100];
+
+function closest(num) {
+  var curr = vals[0];
+  var diff = Math.abs(num - curr);
+  for (var val = 0; val < arr.length; val++) {
+    var newdiff = Math.abs(num - arr[val]);
+    if (newdiff < diff) {
+      diff = newdiff;
+      curr = arr[val];
+    }
+  }
+  return curr;
+}
+
 class DimmerAccessory {
   constructor(platform, homebridgeAccessory, deviceConfig) {
     this.platform = platform;
@@ -93,13 +109,7 @@ class DimmerAccessory {
         this.device
           .get({ dps: this.deviceConfig.dpsMap.brightness })
           .then((status) => {
-            const val = Math.ceil(100 / (255 / status));
-            this.log.info(
-              '[%s] On get brightness is %s - %s',
-              this.homebridgeAccessory.displayName,
-              status,
-              val
-            );
+            const val = closest(Math.ceil(100 / (255 / status)));
             callback(null, val);
           })
           .catch((error) => {
@@ -108,7 +118,7 @@ class DimmerAccessory {
           });
       })
       .on('set', (value, callback) => {
-        const val = Math.floor(255 * (value / 100));
+        const val = Math.floor(255 * (closest(value) / 100));
         this.log.info(
           '[%s] On set brightness to %s - %s',
           this.homebridgeAccessory.displayName,

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -139,7 +139,7 @@ class DimmerAccessory {
               });
             self.dimmerTimeout = null;
           },
-          self.deviceConfig.delay || 1250,
+          this.deviceConfig.delay || 1250,
           this,
           value,
           callback

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -139,7 +139,7 @@ class DimmerAccessory {
               });
             self.dimmerTimeout = null;
           },
-          250,
+          self.deviceConfig.delay || 1250,
           this,
           value,
           callback

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -123,30 +123,28 @@ class DimmerAccessory {
         if (this.dimmerTimeout) {
           clearTimeout(this.dimmerTimeout);
         }
-        this.dimmerTimeout = setTimeout(this.delaySetBrightness, 100, value, callback);
+        this.dimmerTimeout = setTimeout(function() {
+          const pct = closest(value);
+          const val = Math.floor(255 * (pct / 100));
+          this.log.debug('[%s] On set brightness %s', this.homebridgeAccessory.displayName, val);
+
+          this.device
+            .set({ set: val, dps: this.deviceConfig.dpsMap.brightness })
+            .then(() => {
+              callback(null, pct);
+            })
+            .catch((error) => {
+              this.log.error(error);
+              callback(error);
+            });
+          this.dimmerTimeout = null;
+        }, 100);
       });
 
     this.homebridgeAccessory.on('identify', (paired, callback) => {
       this.log.debug('[%s] identify', this.homebridgeAccessory.displayName);
       callback();
     });
-
-    function delaySetBrightness(value, callback) {
-      const pct = closest(value);
-      const val = Math.floor(255 * (pct / 100));
-      this.log.debug('[%s] On set brightness %s', this.homebridgeAccessory.displayName, val);
-
-      this.device
-        .set({ set: val, dps: this.deviceConfig.dpsMap.brightness })
-        .then(() => {
-          callback(null, pct);
-        })
-        .catch((error) => {
-          this.log.error(error);
-          callback(error);
-        });
-      this.dimmerTimeout = null;
-    }
   }
 }
 

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -130,21 +130,20 @@ class DimmerAccessory {
 
             self.device
               .set({ set: val, dps: self.deviceConfig.dpsMap.brightness })
-              /* .then(() => {
+              .then(() => {
                 callback();
-              }) */
+              })
               .catch((error) => {
                 self.log.error(error);
                 callback(error);
               });
             self.dimmerTimeout = null;
           },
-          this.deviceConfig.delay || 1250,
+          this.deviceConfig.delay || 1000,
           this,
           value,
           callback
         );
-        callback();
       });
 
     this.homebridgeAccessory.on('identify', (paired, callback) => {

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -1,0 +1,116 @@
+const TuyaDevice = require('tuyapi');
+
+let PlatformAccessory;
+let Accessory;
+let Service;
+let Characteristic;
+let UUIDGen;
+
+class DimmerAccessory {
+  constructor(platform, homebridgeAccessory, deviceConfig) {
+    this.platform = platform;
+    PlatformAccessory = platform.api.platformAccessory;
+
+    ({ Accessory, Service, Characteristic, uuid: UUIDGen } = platform.api.hap);
+
+    this.log = platform.log;
+    this.homebridgeAccessory = homebridgeAccessory;
+    this.deviceConfig = deviceConfig;
+    this.deviceConfig.dpsMap = {
+      onOff = deviceConfig.dpsOn || 1,
+      brightness = deviceConfig.dpsBright || 2
+    };
+
+    this.device = new TuyaDevice(deviceConfig);
+
+    if (this.homebridgeAccessory) {
+      this.log.debug(
+        'Existing Accessory found [%s] [%s] [%s]',
+        homebridgeAccessory.displayName,
+        homebridgeAccessory.context.deviceId,
+        homebridgeAccessory.UUID
+      );
+      this.homebridgeAccessory.displayName = this.deviceConfig.name;
+    } else {
+      this.log.debug('Creating new Accessory %s', this.deviceConfig.id);
+      this.homebridgeAccessory = new PlatformAccessory(
+        this.deviceConfig.name,
+        UUIDGen.generate(this.deviceConfig.id + this.deviceConfig.name),
+        Accessory.Categories.LIGHTBULB
+      );
+      platform.registerPlatformAccessory(this.homebridgeAccessory);
+    }
+
+    this.dimmerService = this.homebridgeAccessory.getService(Service.Lightbulb);
+    if (this.dimmerService) {
+      this.dimmerService.setCharacteristic(Characteristic.Name, this.deviceConfig.name);
+    } else {
+      this.log.debug('Creating new Service %s', this.deviceConfig.id);
+      this.dimmerService = this.homebridgeAccessory.addService(
+        Service.Lightbulb,
+        this.deviceConfig.name
+      );
+    }
+
+    this.dimmerService
+      .getCharacteristic(Characteristic.On)
+      .on('get', (callback) => {
+        this.log.debug('[%s] On get', this.homebridgeAccessory.displayName);
+
+        this.device
+          .get({ dps: this.deviceConfig.dpsMap.onOff })
+          .then((status) => {
+            callback(null, status);
+          })
+          .catch((error) => {
+            callback(error);
+          });
+      })
+      .on('set', (value, callback) => {
+        this.log.debug('[%s] On set', this.homebridgeAccessory.displayName);
+
+        this.device
+          .set({ set: value, dps: this.deviceConfig.dpsMap.onOff })
+          .then(() => {
+            callback();
+          })
+          .catch((error) => {
+            callback(error);
+          });
+      });
+
+    this.dimmerService
+      .getCharacteristic(Characteristic.Brightness)
+      .on('get', (callback) => {
+        this.log.debug('[%s] On get', this.homebridgeAccessory.displayName);
+
+        this.device
+          .get({ dps: this.deviceConfig.dpsMap.brightness })
+          .then((status) => {
+            callback(null, status);
+          })
+          .catch((error) => {
+            callback(error);
+          });
+      })
+      .on('set', (value, callback) => {
+        this.log.debug('[%s] On set', this.homebridgeAccessory.displayName);
+
+        this.device
+          .set({ set: value, dps: this.deviceConfig.dpsMap.brightness })
+          .then(() => {
+            callback();
+          })
+          .catch((error) => {
+            callback(error);
+          });
+      });
+
+    this.homebridgeAccessory.on('identify', (paired, callback) => {
+      this.log.debug('[%s] identify', this.homebridgeAccessory.displayName);
+      callback();
+    });
+  }
+}
+
+module.exports = DimmerAccessory;

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -89,7 +89,6 @@ class DimmerAccessory {
           });
       })
       .on('set', (value, callback) => {
-        setTimeout();
         this.log.debug('[%s] On set %s', this.homebridgeAccessory.displayName, value);
 
         this.device

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -37,7 +37,7 @@ class DimmerAccessory {
       onOff: deviceConfig.dpsOn || 1,
       brightness: deviceConfig.dpsBright || 2,
     };
-
+    this.dimmerTimeout = null;
     this.device = new TuyaDevice(deviceConfig);
 
     if (this.homebridgeAccessory) {
@@ -89,6 +89,7 @@ class DimmerAccessory {
           });
       })
       .on('set', (value, callback) => {
+        setTimeout();
         this.log.info('[%s] On set %s', this.homebridgeAccessory.displayName, value);
 
         this.device
@@ -119,24 +120,23 @@ class DimmerAccessory {
           });
       })
       .on('set', (value, callback) => {
-        const pct = closest(value);
-        const val = Math.floor(255 * (pct / 100));
-        this.log.info(
-          '[%s] On set brightness to %s - %s',
-          this.homebridgeAccessory.displayName,
-          value,
-          val
-        );
-
-        this.device
-          .set({ set: val, dps: this.deviceConfig.dpsMap.brightness })
-          .then(() => {
-            callback(null, pct);
-          })
-          .catch((error) => {
-            this.log.error(error);
-            callback(error);
-          });
+        if (this.dimmerTimeout) {
+          clearTimeout(this.dimmerTimeout);
+        }
+        this.dimmerTimeout = setTimeout(() => {
+          const pct = closest(value);
+          const val = Math.floor(255 * (pct / 100));
+          this.device
+            .set({ set: val, dps: this.deviceConfig.dpsMap.brightness })
+            .then(() => {
+              callback(null, pct);
+            })
+            .catch((error) => {
+              this.log.error(error);
+              callback(error);
+            });
+          this.dimmerTimeout = null;
+        }, 100);
       });
 
     this.homebridgeAccessory.on('identify', (paired, callback) => {

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -118,7 +118,8 @@ class DimmerAccessory {
           });
       })
       .on('set', (value, callback) => {
-        const val = Math.floor(255 * (closest(value) / 100));
+        const pct = closest(value);
+        const val = Math.floor(255 * (pct / 100));
         this.log.info(
           '[%s] On set brightness to %s - %s',
           this.homebridgeAccessory.displayName,
@@ -129,7 +130,7 @@ class DimmerAccessory {
         this.device
           .set({ set: val, dps: this.deviceConfig.dpsMap.brightness })
           .then(() => {
-            callback();
+            callback(null, pct);
           })
           .catch((error) => {
             this.log.error(error);

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -10,7 +10,8 @@ let UUIDGen;
 const vals = [0, 20, 40, 60, 80, 100];
 
 function closest(num) {
-  var curr = vals[0];
+  const arr = vals;
+  var curr = arr[0];
   var diff = Math.abs(num - curr);
   for (var val = 0; val < arr.length; val++) {
     var newdiff = Math.abs(num - arr[val]);

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -125,13 +125,10 @@ class DimmerAccessory {
           function(self, value, callback) {
             const pct = closest(value);
             const val = Math.floor(255 * (pct / 100));
-            self.log.info('[%s] On set brightness %s', self.homebridgeAccessory.displayName, val);
+            self.log.debug('[%s] On set brightness %s', self.homebridgeAccessory.displayName, val);
 
             self.device
               .set({ set: val, dps: self.deviceConfig.dpsMap.brightness })
-              /* .then(() => {
-                callback();
-              }) */
               .catch((error) => {
                 self.log.error(error);
                 callback(error);

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -108,7 +108,7 @@ class DimmerAccessory {
           });
       })
       .on('set', (value, callback) => {
-        const val = Math.floor(255 * (pct / 100));
+        const val = Math.floor(255 * (value / 100));
         this.log.info(
           '[%s] On set brightness to %s - %s',
           this.homebridgeAccessory.displayName,

--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -22,7 +22,6 @@ class DimmerAccessory {
     };
     this.minVal = this.deviceConfig.minVal || 11;
     this.maxVal = this.deviceConfig.maxVal || 244;
-    this.dimmerTimeout = null;
     this.device = new TuyaDevice(deviceConfig);
 
     if (this.homebridgeAccessory) {
@@ -110,31 +109,25 @@ class DimmerAccessory {
           });
       })
       .on('set', (value, callback) => {
-        clearTimeout(this.dimmerTimeout);
         this.log.info('[%s] On set brightness', this.homebridgeAccessory.displayName);
 
-        this.dimmerTimeout = setTimeout(
-          function(self, value, callback) {
-            const val = self.minVal + Math.ceil((value * self.maxVal) / 100);
-            self.log.info(
-              '[%s] \tSet brightness %s from %s',
-              self.homebridgeAccessory.displayName,
-              val,
-              value
-            );
-
-            self.device.set({ set: val, dps: self.dpsMap.brightness }).catch((error) => {
-              self.log.error(error);
-              callback(error);
-            });
-            self.dimmerTimeout = null;
-          },
-          this.deviceConfig.delay || 1000,
-          this,
-          value,
-          callback
+        const val = self.minVal + Math.ceil((value * self.maxVal) / 100);
+        self.log.info(
+          '[%s] \tSet brightness %s from %s',
+          self.homebridgeAccessory.displayName,
+          val,
+          value
         );
-        callback();
+
+        self.device
+          .set({ set: val, dps: self.dpsMap.brightness })
+          .then(() => {
+            callback();
+          })
+          .catch((error) => {
+            self.log.error(error);
+            callback(error);
+          });
       });
 
     this.homebridgeAccessory.on('identify', (paired, callback) => {

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -11,30 +11,24 @@ class TuyaDiscover extends EventEmitter {
 
   async startDiscovery() {
     for (const device of this.config) {
-      if (device.ip) {
-        this.log.info('Device has IP: %s', device.ip);
+      try {
+        // Construct a new device and resolve the IP
+        const tuyaDevice = new TuyaDevice({ id: device.id, key: device.key, ip: device.ip });
+
+        // eslint-disable-next-line no-await-in-loop
+        await tuyaDevice.resolveId();
+
+        device.ip = tuyaDevice.device.ip;
+
+        this.log.info('Device %s has IP %s', device.id, device.ip);
 
         this.emit('device-new', device);
-      } else {
-        try {
-          // Construct a new device and resolve the IP
-          const tuyaDevice = new TuyaDevice({ id: device.id, key: device.key });
-
-          // eslint-disable-next-line no-await-in-loop
-          await tuyaDevice.resolveId();
-
-          device.ip = tuyaDevice.device.ip;
-
-          this.log.info('Device %s has IP %s', device.id, device.ip);
-
-          this.emit('device-new', device);
-        } catch (error) {
-          this.log.error(
-            '%s was unable to be found. Please try using a static IP in your config.json.',
-            device.id
-          );
-          this.emit('device-offline', device);
-        }
+      } catch (error) {
+        this.log.error(
+          '%s was unable to be found. Please try using a static IP in your config.json.',
+          device.id
+        );
+        this.emit('device-offline', device);
       }
     }
   }

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -11,24 +11,30 @@ class TuyaDiscover extends EventEmitter {
 
   async startDiscovery() {
     for (const device of this.config) {
-      try {
-        // Construct a new device and resolve the IP
-        const tuyaDevice = new TuyaDevice({ id: device.id, key: device.key, ip: device.ip });
-
-        // eslint-disable-next-line no-await-in-loop
-        await tuyaDevice.resolveId();
-
-        device.ip = tuyaDevice.device.ip;
-
-        this.log.info('Device %s has IP %s', device.id, device.ip);
+      if (device.ip) {
+        this.log.info('Device has IP: %s', device.ip);
 
         this.emit('device-new', device);
-      } catch (error) {
-        this.log.error(
-          '%s was unable to be found. Please try using a static IP in your config.json.',
-          device.id
-        );
-        this.emit('device-offline', device);
+      } else {
+        try {
+          // Construct a new device and resolve the IP
+          const tuyaDevice = new TuyaDevice({ id: device.id, key: device.key });
+
+          // eslint-disable-next-line no-await-in-loop
+          await tuyaDevice.resolveId();
+
+          device.ip = tuyaDevice.device.ip;
+
+          this.log.info('Device %s has IP %s', device.id, device.ip);
+
+          this.emit('device-new', device);
+        } catch (error) {
+          this.log.error(
+            '%s was unable to be found. Please try using a static IP in your config.json.',
+            device.id
+          );
+          this.emit('device-offline', device);
+        }
       }
     }
   }

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -12,13 +12,13 @@ class TuyaDiscover extends EventEmitter {
   async startDiscovery() {
     for (const device of this.config) {
       if (device.ip) {
-        this.log.info('Device has IP: %s', device.id);
+        this.log.info('Device has IP: %s', device.ip);
 
         this.emit('device-new', device);
       } else {
         try {
           // Construct a new device and resolve the IP
-          const tuyaDevice = new TuyaDevice({id: device.id, key: device.key});
+          const tuyaDevice = new TuyaDevice({ id: device.id, key: device.key });
 
           // eslint-disable-next-line no-await-in-loop
           await tuyaDevice.resolveId();
@@ -29,7 +29,10 @@ class TuyaDiscover extends EventEmitter {
 
           this.emit('device-new', device);
         } catch (error) {
-          this.log.error('%s was unable to be found. Please try using a static IP in your config.json.', device.id);
+          this.log.error(
+            '%s was unable to be found. Please try using a static IP in your config.json.',
+            device.id
+          );
           this.emit('device-offline', device);
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-tuya",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A Homebridge plugin for Tuya devices",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Added optional ability to use a tuya based dimmer switch, not a color bulb, just the dimmer. Tested with six simultaneous [MJ-SD01](https://smile.amazon.com/gp/product/B07FXYSVR1) controlling LED lights via Homebridge on HomePod, Apple Watch, and iPhone. Works as expected with scenes and triggers.