### PR TITLE
Redundant get Request

### DIFF
--- a/lib/dimmer.js
+++ b/lib/dimmer.js
@@ -29,7 +29,7 @@ class DimmerAccessory {
     checkDimmerOptionsUpgrade(this.deviceConfig, this.log);
 
     this.deviceConfig.options = this.deviceConfig.options || {};
-    
+
     this.dpsMap = {
       onOff: ('dpsOn' in this.deviceConfig.options) ? this.deviceConfig.options.dpsOn : 1,
       brightness: ('dpsBright' in this.deviceConfig.options) ? this.deviceConfig.options.dpsBright : 2,
@@ -116,19 +116,6 @@ class DimmerAccessory {
 
     this.dimmerService
       .getCharacteristic(Characteristic.On)
-      .on('get', callback => {
-        this.log.debug('[%s] On get', this.homebridgeAccessory.displayName);
-
-        this.device
-          .get({dps: this.dpsMap.onOff})
-          .then(status => {
-            callback(null, status);
-          })
-          .catch(error => {
-            this.log.error(error);
-            callback(error);
-          });
-      })
       .on('set', (value, callback) => {
         this.log.debug('[%s] On set %s', this.homebridgeAccessory.displayName, value);
 
@@ -145,26 +132,6 @@ class DimmerAccessory {
 
     this.dimmerService
       .getCharacteristic(Characteristic.Brightness)
-      .on('get', callback => {
-        this.log.debug('[%s] On get brightness', this.homebridgeAccessory.displayName);
-
-        this.device
-          .get({dps: this.dpsMap.brightness})
-          .then(value => {
-            const percent = Math.floor(((value - this.minVal) / this.maxVal) * 100);
-            this.log.debug(
-              '[%s] \tGet brightness %s from %s',
-              this.homebridgeAccessory.displayName,
-              percent,
-              value
-            );
-            callback(null, percent);
-          })
-          .catch(error => {
-            this.log.error(error);
-            callback(error);
-          });
-      })
       .on('set', (percent, callback) => {
         this.log.debug('[%s] On set brightness', this.homebridgeAccessory.displayName);
 


### PR DESCRIPTION
This HAP Get Event handler is redundant when using events and updateValue.  And actually slows down the time it takes the Home app to open.  ( In my setup it adds 5 seconds to the Home App startup time.)

Max, this got missed/dropped in the original Pull request for events.  And I just found this when I was looking into why my Home app was so slow to start up.